### PR TITLE
Illegal offset in EventManager: vendor/cakephp/cakephp/src/Event/Even…

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -172,6 +172,11 @@ class EventManager
 
             return;
         }
+
+        if  (is_object($eventKey) &&  !($eventKey instanceof EventListenerInterface)) {
+             throw new InvalidArgumentException('Invalid arguments for EventManager::on(). Listener Object must use EventListenerInterface.');   
+        }
+                
         $argCount = func_num_args();
         if ($argCount === 2) {
             $this->_listeners[$eventKey][static::$defaultPriority][] = [


### PR DESCRIPTION
Make sure the provided object is instance of EventListenerInterface and not some dummy object  which would cause "dummy" error message:

 Illegal offset type [in ....vendor/cakephp/cakephp/src/Event/EventManager.php, line 117]

This commit would provide better error message feedback to software developer. Application stack  dies quickly rather than run with possibly hidden warnings, and not do as intended.